### PR TITLE
Fix occasional double-link for archive.today

### DIFF
--- a/botbot/Module/SlackAttachments/ArchiveTodayAttachmentModule.cs
+++ b/botbot/Module/SlackAttachments/ArchiveTodayAttachmentModule.cs
@@ -29,12 +29,18 @@ namespace botbot.Module.SlackAttachments
 
             string urlLower = url.ToLower();
 
+            if (urlLower.Contains("archive.today"))
+            {
+                return Task.FromResult(new ModuleResponse());
+            }
+
             foreach (var domain in domains) 
             {
-                if (urlLower.Contains(domain)) {
+                if (urlLower.Contains(domain)) 
+                {
                     return Task.FromResult(new ModuleResponse() 
                     {
-                        Message = "Paywall bypass: https://archive.today/" + url,
+                        Message = $"Paywall bypass: https://archive.today/{url}",
                         Timestamp = message.Message.ThreadTimestamp
                     });
                 }


### PR DESCRIPTION
Sometimes this was posting a second message like `https://archive.today/https://archive.today/https://www.bloomberg.com/graphics/2024-uber-lyft-nyc-drivers-pay-lockouts/`

So ignore if we already have archive.today links